### PR TITLE
Add method and blueprint for active employee_teams

### DIFF
--- a/app/blueprints/team_blueprint.rb
+++ b/app/blueprints/team_blueprint.rb
@@ -2,8 +2,11 @@ class TeamBlueprint < Blueprinter::Base
     identifier :id
   
     view :teams_list do
-      fields :name, :description, :employees_with_dates
+      fields :name, :description, :employees_with_active_dates
+    end
 
+    view :teams_history do
+      fields :name, :description, :employees_with_dates
     end
   end
   

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -20,6 +20,17 @@ class Team < ApplicationRecord
             employee_hash
         end
     end
+
+    # Access active team employees
+    def employees_with_active_dates
+        employee_teams.where(end_date: nil).order(:sort_order).includes(:employee).map do |employee_team|
+            employee_hash = EmployeeBlueprint.render_as_hash(employee_team.employee)
+            employee_hash[:start_date] = employee_team.start_date
+            employee_hash[:end_date] = employee_team.end_date
+            employee_hash
+        end
+    end
+
     def soft_delete
         update(is_deleted: true)
     end


### PR DESCRIPTION
In the Teams model, I added a method called employees_with_active_dates that filters employee_teams with an end_date that is nil.

In the Teams blueprint, I updated the existing :teams-list view with the active list. I added a new :teams-history that will display active and inactive employee_teams using employees_with_dates.